### PR TITLE
Adding standard http metrics to fleetlock.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/golang:1.17.3 AS builder
 COPY . src
 RUN cd src && make build
 
-FROM docker.io/alpine:3.14.2
+FROM docker.io/alpine:3.14.3
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 RUN apk --no-cache --update add ca-certificates
 COPY --from=builder /go/src/bin/fleetlock /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.17.2 AS builder
+FROM docker.io/golang:1.17.3 AS builder
 COPY . src
 RUN cd src && make build
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/tools v0.1.7 // indirect
 	k8s.io/api v0.22.3
 	k8s.io/apimachinery v0.22.3
 	k8s.io/client-go v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -270,6 +271,8 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -278,6 +281,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -305,6 +309,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 h1:ADo5wSpq2gqaCGQWzk7S5vd//0iyyLeAratkEoG5dLE=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -319,6 +325,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -357,6 +364,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -405,6 +414,8 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.7 h1:6j8CgantCy3yc8JGBqkDLMKWqZ0RDU2g1HVgacojGWQ=
+golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -2,10 +2,30 @@ package fleetlock
 
 import (
 	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// Makes a responseWriter
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{w, http.StatusOK}
+}
+
+// Writes the header code into the response and makes it available for logging
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
 
 const (
 	fleetLockHeaderKey = "fleet-lock-protocol"
+	millisecondsInSec  = 1000
 )
 
 // POSTHandler returns a handler that requires the POST method.
@@ -28,6 +48,27 @@ func HeaderHandler(key, value string, next http.Handler) http.Handler {
 			return
 		}
 		next.ServeHTTP(w, req)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// InstrumentedHandler returns a handler that instruments http requests
+func InstrumentedHandler(totalRequests, responseStatus *prometheus.CounterVec, httpDuration *prometheus.HistogramVec, next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		path := req.URL.Path
+		timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+			ms := v * millisecondsInSec // make microseconds
+			httpDuration.WithLabelValues(path).Observe(ms)
+		}))
+		defer timer.ObserveDuration()
+		rw := newResponseWriter(w)
+		next.ServeHTTP(rw, req)
+
+		responseStatus.With(prometheus.Labels{
+			"path":   path,
+			"status": strconv.Itoa(rw.statusCode),
+		}).Inc()
+		totalRequests.WithLabelValues(path).Inc()
 	}
 	return http.HandlerFunc(fn)
 }

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -10,6 +10,9 @@ type metrics struct {
 	lockTransitions *prometheus.GaugeVec
 	lockRequests    prometheus.Counter
 	unlockRequests  prometheus.Counter
+	totalRequests   *prometheus.CounterVec
+	responseStatus  *prometheus.CounterVec
+	httpDuration    *prometheus.HistogramVec
 }
 
 // newMetrics creates fleetlock Prometheus metrics.
@@ -33,12 +36,28 @@ func newMetrics() *metrics {
 		Name: "fleetlock_unlock_request_count",
 		Help: "Number of unlock requests",
 	})
+	totalRequests := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Number of requests",
+	}, []string{"path"})
+	responseStatus := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_response_status",
+		Help: "Status of HTTP response",
+	}, []string{"path", "status"})
+	httpDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "http_response_time_millis",
+		Help:    "Duration of HTTP requests in milliseconds",
+		Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+	}, []string{"path"})
 
 	return &metrics{
 		lockState:       lockState,
 		lockTransitions: lockTransitions,
 		lockRequests:    lockRequests,
 		unlockRequests:  unlockRequests,
+		totalRequests:   totalRequests,
+		responseStatus:  responseStatus,
+		httpDuration:    httpDuration,
 	}
 }
 
@@ -49,6 +68,9 @@ func (m *metrics) Register(registry prometheus.Registerer) error {
 		m.lockTransitions,
 		m.lockRequests,
 		m.unlockRequests,
+		m.totalRequests,
+		m.responseStatus,
+		m.httpDuration,
 	}
 
 	return registerAll(registry, collectors...)

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -41,12 +41,12 @@ func newMetrics() *metrics {
 		Help: "Number of requests",
 	}, []string{"path"})
 	responseStatus := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "http_response_status",
+		Name: "http_response_status_total",
 		Help: "Status of HTTP response",
 	}, []string{"path", "status"})
 	httpDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "http_response_time_millis",
-		Help:    "Duration of HTTP requests in milliseconds",
+		Name:    "http_response_time_seconds",
+		Help:    "Duration of HTTP requests in seconds",
 		Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
 	}, []string{"path"})
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -79,7 +79,7 @@ func NewServer(config *Config) (http.Handler, error) {
 
 	mux := http.NewServeMux()
 	chain := func(next http.Handler) http.Handler {
-		return POSTHandler(HeaderHandler(fleetLockHeaderKey, "true", next))
+		return InstrumentedHandler(s.metrics.totalRequests, s.metrics.responseStatus, s.metrics.httpDuration, POSTHandler(HeaderHandler(fleetLockHeaderKey, "true", next)))
 	}
 	mux.Handle("/v1/pre-reboot", chain(http.HandlerFunc(s.lock)))
 	mux.Handle("/v1/steady-state", chain(http.HandlerFunc(s.unlock)))


### PR DESCRIPTION
This adds the following metrics to fleetlock:
`http_requests_total`
`http_repsonse_status`
`http_response_time_millis`

Each are labeled by the path of the request. Additionally `http_repsonse_status` has the http response code as a label.