### PR TITLE
[COMPUTE-5061] Enable option for disabling node operations

### DIFF
--- a/internal/decode.go
+++ b/internal/decode.go
@@ -9,8 +9,9 @@ import (
 // Message represents a FleetLock protocol client request.
 type Message struct {
 	ClientParmas struct {
-		ID    string `json:"id"`
-		Group string `json:"group"`
+		ID          string `json:"id"`
+		Group       string `json:"group"`
+		SkipNodeOps bool   `json:"skip_node_ops"`
 	} `json:"client_params"`
 }
 


### PR DESCRIPTION
We want the ability to use fleetlock as a distributed lock
for another service, imagepatchpull. This service does not
require the node to be cordoned. However, the fleetlock server
will always attempt to cordon on lock, uncordon on unlock.

Therefore, this change provides an optional parameter to allow
disabling node operations. By using this option, imagepatchpull
can use fleetlock to get distributed locks without any node
operations.